### PR TITLE
URL Cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # Version 2.0 (the "License?); you may not use this file except in compliance
 # with the License. You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+# https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ RUN apt-get update -y
 RUN \
   apt-get install -y wget && \
   wget -q -O - http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key | apt-key add - && \
-  echo "deb http://pkg.jenkins-ci.org/debian binary/" > /etc/apt/sources.list.d/jenkins.list && \
+  echo "deb http://pkg.jenkins-ci.org/debian/ binary/" > /etc/apt/sources.list.d/jenkins.list && \
   apt-get install -y jenkins openjdk-7-jdk iptables ca-certificates lxc
 
 ADD https://get.docker.io/builds/Linux/x86_64/docker-latest /usr/local/bin/docker

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <license>
       <name>BSD</name>
       <comments>All source code is under the BSD license.</comments>
-      <url>http://opensource.org/licenses/BSD-3-Clause</url>
+      <url>https://opensource.org/licenses/BSD-3-Clause</url>
     </license>
   </licenses>
 
@@ -64,7 +64,7 @@
   <scm>
     <connection>scm:git:git://github.com/pivotalsoftware/CIBorium.git</connection>
     <developerConnection>scm:git:git@github.com:pivotalsoftware/CIBorium.git</developerConnection>
-    <url>http://github.com/pivotalsoftware/CIBorium</url>
+    <url>https://github.com/pivotalsoftware/CIBorium</url>
   </scm>
 
   <dependencies>
@@ -117,14 +117,14 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 </project>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key (200) could not be migrated:  
   ([https](https://pkg.jenkins-ci.org/debian/jenkins-ci.org.key) result SSLHandshakeException).
* http://pkg.jenkins-ci.org/debian (301) could not be migrated:  
   ([https](https://pkg.jenkins-ci.org/debian) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://repo.jenkins-ci.org/public/ (405) migrated to:  
  https://repo.jenkins-ci.org/public/ ([https](https://repo.jenkins-ci.org/public/) result 405).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://github.com/pivotalsoftware/CIBorium migrated to:  
  https://github.com/pivotalsoftware/CIBorium ([https](https://github.com/pivotalsoftware/CIBorium) result 200).
* http://opensource.org/licenses/BSD-3-Clause migrated to:  
  https://opensource.org/licenses/BSD-3-Clause ([https](https://opensource.org/licenses/BSD-3-Clause) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://www.w3.org/2001/XMLSchema-instance