### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
@@ -49,7 +49,7 @@
     <license>
       <name>BSD</name>
       <comments>All source code is under the BSD license.</comments>
-      <url>http://opensource.org/licenses/BSD-3-Clause</url>
+      <url>https://opensource.org/licenses/BSD-3-Clause</url>
     </license>
   </licenses>
 
@@ -64,7 +64,7 @@
   <scm>
     <connection>scm:git:git://github.com/pivotalsoftware/CIBorium.git</connection>
     <developerConnection>scm:git:git@github.com:pivotalsoftware/CIBorium.git</developerConnection>
-    <url>http://github.com/pivotalsoftware/CIBorium</url>
+    <url>https://github.com/pivotalsoftware/CIBorium</url>
   </scm>
 
   <dependencies>
@@ -117,14 +117,14 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 </project>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://repo.jenkins-ci.org/public/ (405) with 2 occurrences migrated to:  
  https://repo.jenkins-ci.org/public/ ([https](https://repo.jenkins-ci.org/public/) result 405).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://github.com/pivotalsoftware/CIBorium with 1 occurrences migrated to:  
  https://github.com/pivotalsoftware/CIBorium ([https](https://github.com/pivotalsoftware/CIBorium) result 200).
* http://opensource.org/licenses/BSD-3-Clause with 1 occurrences migrated to:  
  https://opensource.org/licenses/BSD-3-Clause ([https](https://opensource.org/licenses/BSD-3-Clause) result 200).
* http://maven.apache.org/maven-v4_0_0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences