### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CIBorium
 
-CIBorium is a [Jenkins](http://jenkins-ci.org/) plugin that integrates with [Docker](https://www.docker.com/). This will let you create and publish docker images, and will also let you run build steps inside a docker container.
+CIBorium is a [Jenkins](https://jenkins-ci.org/) plugin that integrates with [Docker](https://www.docker.com/). This will let you create and publish docker images, and will also let you run build steps inside a docker container.
 
 ## Licensing
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://jenkins-ci.org/ with 1 occurrences migrated to:  
  https://jenkins-ci.org/ ([https](https://jenkins-ci.org/) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080 with 1 occurrences