### PR TITLE
URL Cleanup

### DIFF
--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -6,7 +6,7 @@
     Version 2.0 (the "License?); you may not use this file except in compliance
     with the License. You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/org/jenkinsci/plugins/ciborium/DockerBuildImageBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ciborium/DockerBuildImageBuilder/config.jelly
@@ -6,7 +6,7 @@
     Version 2.0 (the "License?); you may not use this file except in compliance
     with the License. You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/org/jenkinsci/plugins/ciborium/DockerBuildWrapper/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ciborium/DockerBuildWrapper/config.jelly
@@ -6,7 +6,7 @@
     Version 2.0 (the "License?); you may not use this file except in compliance
     with the License. You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/org/jenkinsci/plugins/ciborium/DockerImagePullBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ciborium/DockerImagePullBuilder/config.jelly
@@ -6,7 +6,7 @@
     Version 2.0 (the "License?); you may not use this file except in compliance
     with the License. You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 4 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).